### PR TITLE
fix: 處理 mail 的 View 檔名大小寫不符

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,14 +11,14 @@ LOG_LEVEL=debug
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
 DB_PORT=3306
-DB_DATABASE=laravel
-DB_USERNAME=root
+DB_DATABASE=momShopping
+DB_USERNAME=
 DB_PASSWORD=
 
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file
 FILESYSTEM_DISK=local
-# QUEUE_CONNECTION=sync
+# use queue then "database"
 QUEUE_CONNECTION=database
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
@@ -32,7 +32,6 @@ REDIS_PORT=6379
 # gmail 寄信設定
 MAIL_MAILER=smtp
 MAIL_HOST=smtp.gmail.com
-# MAIL_PORT=1025
 MAIL_PORT=587
 # 寄信方，也就是你申請應用程式密碼的 gmail
 MAIL_USERNAME=xxxxxxx@gmail.com 

--- a/app/Mail/WellcomeMomShopping.php
+++ b/app/Mail/WellcomeMomShopping.php
@@ -32,7 +32,7 @@ class WellcomeMomShopping extends Mailable
         // 資料傳給 blade 前自訂其格式，使用 Content 定義的 with 參數來手動將資料傳給 View
         $member = $this->member;
         return new Content(
-            view: 'mail.wellcomeMomshopping',
+            view: 'mail.wellcomeMomShopping',
             with:[
                 'memberName' => $member->name, 
             ],


### PR DESCRIPTION
- Local 端測試時，未發現檔名大小寫的差異，AWS 上的 OS (Linux: ubuntu) 會把檔名大小寫不同，判斷成不同檔案。
- 部屬 AWS 時，若完全重新 cp 一個 .env.example ，記得生成 - APP_KEY：`php artisan key:generate` - JWT_SECRET：`php artisan jwt:secret`
- .env.example 補上固定值：DB_DATABASE，另外 DB_USERNAME、 DB_PASSWORD 上 AWS 在自行填入